### PR TITLE
[#115] Refactor: N+1 문제 해결 및 JPA 쿼리 성능 개선

### DIFF
--- a/src/main/java/com/sajang/devracebackend/domain/Room.java
+++ b/src/main/java/com/sajang/devracebackend/domain/Room.java
@@ -40,8 +40,10 @@ public class Room extends BaseEntity implements Serializable{
     @JoinColumn(name = "problem_id")
     private Problem problem;
 
+    // 밑처럼 과도한 N+1 문제를 유발할 서비스 로직이 없을뿐더러 활용 빈도수도 낮기때문에, fetch join이나 @EntityGraph를 사용하지 않은채로 지연 로딩을 유지하도록 했음.
+    // 과도한 N+1 예시: Rooms를 JPA의 findAll()로 호출하고, 각 Room을 순회하며 room.getUserRoomList.get내부속성()으로 접근하는 경우.
     @OneToMany(mappedBy = "room")  // Room-UserRoom 양방향매핑 (읽기 전용 필드)
-    private List<UserRoom> userRoomList = new ArrayList<>();  // 방의 입장인원 전원 퇴장여부 확인용도에 활용.
+    private List<UserRoom> userRoomList = new ArrayList<>();  // '방의 입장인원 전원 퇴장여부 확인 용도'에 활용.
 
 
     @Builder(builderClassName = "RoomSaveBuilder", builderMethodName = "RoomSaveBuilder")

--- a/src/main/java/com/sajang/devracebackend/domain/User.java
+++ b/src/main/java/com/sajang/devracebackend/domain/User.java
@@ -47,8 +47,10 @@ public class User extends BaseEntity implements Serializable {
     @Column(name = "refresh_token")
     private String refreshToken;
 
+    // 밑처럼 과도한 N+1 문제를 유발할 서비스 로직이 없을뿐더러 활용 빈도수도 낮기때문에, fetch join이나 @EntityGraph를 사용하지 않은채로 지연 로딩을 유지하도록 했음.
+    // 과도한 N+1 예시: Users를 JPA의 findAll()로 호출하고, 각 User를 순회하며 user.getUserRoomList.get내부속성()으로 접근하는 경우.
     @OneToMany(mappedBy = "user")  // User-UserRoom 양방향매핑 (읽기 전용 필드)
-    private List<UserRoom> userRoomList = new ArrayList<>();  // 사용자의 참여중인 방 찾는 용도에 활용.
+    private List<UserRoom> userRoomList = new ArrayList<>();  // '사용자의 참여중인 방 찾는 용도 & 회원탈퇴 용도'에 활용.
 
 
     @Builder(builderClassName = "UserSaveBuilder", builderMethodName = "UserSaveBuilder")

--- a/src/main/java/com/sajang/devracebackend/domain/mapping/UserRoom.java
+++ b/src/main/java/com/sajang/devracebackend/domain/mapping/UserRoom.java
@@ -43,7 +43,7 @@ public class UserRoom extends BaseEntity implements Serializable {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)  // Room-UserRoom 양방향매핑
+    @ManyToOne(fetch = FetchType.LAZY)  // Room-UserRoom 양방향매핑 (default로 Lazy를 적용하되, Eager가 필요할경우 따로 메소드를 만들어 사용함.)
     @JoinColumn(name = "room_id")
     private Room room;
 

--- a/src/main/java/com/sajang/devracebackend/repository/UserRoomRepository.java
+++ b/src/main/java/com/sajang/devracebackend/repository/UserRoomRepository.java
@@ -5,15 +5,22 @@ import com.sajang.devracebackend.domain.User;
 import com.sajang.devracebackend.domain.mapping.UserRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
-    Optional<UserRoom> findByUserAndRoom(User user, Room room);
+
+    // 서비스 로직에 UserRoom과 내부의 Room 정보를 모두 조회하여 사용하는 경우가 많았기에, 이를 적용하였음.
+    // @EntityGraph를 통해 UserRoom 조회시, 내부의 Lazy 로딩으로 선언된 Room 또한 Eager로 한번에 조회하여, N+1 문제를 해결.
+    // ==> Eager 조회 : 'UserRoom + 내부 Room', Lazy 조회 : '내부 User'
+    @EntityGraph(attributePaths = {"room"})
+    Optional<UserRoom> findByUser_IdAndRoom_Id(Long userId, Long roomId);
+
     boolean existsByUserAndRoom(User user, Room room);
 
-    Page<UserRoom> findAllByIsLeaveAndUser(Integer isLeave, User user, Pageable pageable);
+    Page<UserRoom> findAllByIsLeaveAndUser_Id(Integer isLeave, Long userId, Pageable pageable);
     Page<UserRoom> findAllByIsLeaveAndIsPass(Integer isLeave, Integer isPass, Pageable pageable);
     Page<UserRoom> findAllByIsLeaveAndRoom_Problem_Number(Integer isLeave, Integer number, Pageable pageable);
     Page<UserRoom> findAllByIsLeaveAndRoom_Link(Integer isLeave, String link, Pageable pageable);

--- a/src/main/java/com/sajang/devracebackend/service/UserRoomService.java
+++ b/src/main/java/com/sajang/devracebackend/service/UserRoomService.java
@@ -1,7 +1,5 @@
 package com.sajang.devracebackend.service;
 
-import com.sajang.devracebackend.domain.Room;
-import com.sajang.devracebackend.domain.User;
 import com.sajang.devracebackend.domain.mapping.UserRoom;
 import com.sajang.devracebackend.dto.room.RoomWaitRequestDto;
 import com.sajang.devracebackend.dto.room.RoomWaitResponseDto;
@@ -13,7 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface UserRoomService {
-    UserRoom findUserRoom(User user, Room room);
+    UserRoom findUserRoom(Long userId, Long roomId);  // Eager 조회 : 'UserRoom + 내부 Room', Lazy 조회 : '내부 User'
     RoomWaitResponseDto userWaitRoom(RoomWaitRequestDto roomWaitRequestDto);
     void usersEnterRoom(Long roomId);
     void userStopWaitRoom(Long roomId);

--- a/src/main/java/com/sajang/devracebackend/service/impl/UserRoomServiceImpl.java
+++ b/src/main/java/com/sajang/devracebackend/service/impl/UserRoomServiceImpl.java
@@ -20,6 +20,7 @@ import com.sajang.devracebackend.response.exception.exception404.NoSuchUserRoomE
 import com.sajang.devracebackend.service.RoomService;
 import com.sajang.devracebackend.service.UserRoomService;
 import com.sajang.devracebackend.service.UserService;
+import com.sajang.devracebackend.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -40,11 +42,14 @@ public class UserRoomServiceImpl implements UserRoomService {
     private final ChatRepository chatRepository;
 
 
+    // 서비스 로직에 UserRoom과 내부의 Room 정보를 모두 조회하여 사용하는 경우가 많았기에, 이를 적용하였음.
+    // @EntityGraph를 통해 UserRoom 조회시, 내부의 Lazy 로딩으로 선언된 Room 또한 Eager로 한번에 조회하여, N+1 문제를 해결.
+    // ==> Eager 조회 : 'UserRoom + 내부 Room', Lazy 조회 : '내부 User'
     @Transactional(readOnly = true)
     @Override
-    public UserRoom findUserRoom(User user, Room room) {
-        return userRoomRepository.findByUserAndRoom(user, room).orElseThrow(
-                ()->new NoSuchUserRoomException(String.format("userId = %d & roomId = %d", user.getId(), room.getId())));
+    public UserRoom findUserRoom(Long userId, Long roomId) {
+        return userRoomRepository.findByUser_IdAndRoom_Id(userId, roomId).orElseThrow(
+                ()->new NoSuchUserRoomException(String.format("userId = %d & roomId = %d", userId, roomId)));
     }
 
     @Transactional
@@ -117,43 +122,51 @@ public class UserRoomServiceImpl implements UserRoomService {
     @Transactional
     @Override
     public void userStopWaitRoom(Long roomId) {
-        User loginUser = userService.findLoginUser();
         Room room = roomService.findRoom(roomId);
-
-        room.deleteWaiting(loginUser.getId(), false);  // 대기자 목록에서 해당 사용자 제거.
+        room.deleteWaiting(SecurityUtil.getCurrentMemberId(), false);  // 대기자 목록에서 해당 사용자 제거.
     }
 
     @Transactional(readOnly = true)
     @Override
     public SolvingPageResponseDto loadSolvingPage(Long roomId) {
-        User user = userService.findLoginUser();
-        Room room = roomService.findRoom(roomId);
-        UserRoom userRoom = findUserRoom(user, room);
+        UserRoom userRoom = findUserRoom(SecurityUtil.getCurrentMemberId(), roomId);  // 어차피 문제풀이 페이지는 입장 이후이기에, 부모 Room을 갖고있는 자식 UserRoom은 반드시 존재함.
 
-        List<Long> rankUserIdList = room.getWaiting();
+        List<Long> rankUserIdList = userRoom.getRoom().getWaiting();  // @EntityGraph로 UserRoom 내부의 Room은 Eager 로딩 처리되어, N+1 문제가 발생하지 않음.
         List<UserResponseDto> rankUserDtoList = userService.findUsersOriginal(rankUserIdList, true);
 
-        return new SolvingPageResponseDto(userRoom, rankUserDtoList);
+        return new SolvingPageResponseDto(userRoom, rankUserDtoList);  // UserRoom의 Room의 Problem은 호출 빈도수가 낮기도하고, JPA메소드 네이밍이 겹치기에, eager 적용을 하지 않았음.
     }
 
     @Transactional(readOnly = true)
     @Override
     public RoomCheckAccessResponseDto checkAccess(Long roomId) {
-        User user = userService.findLoginUser();
-        Room room = roomService.findRoom(roomId);
-        UserRoom userRoom = userRoomRepository.findByUserAndRoom(user, room)
-                .orElse(null);
+        System.out.println("========== !!! 메소드 시작 !!! ==========\n");
 
-        Boolean isExistUserRoom = true;
-        if(userRoom == null) isExistUserRoom = false;
-        Integer isLeave = null;
-        if(userRoom != null) isLeave = userRoom.getIsLeave();
+        System.out.println("===== UserRoom 조회 =====");
+        Optional<UserRoom> optionalUserRoom = userRoomRepository.findByUser_IdAndRoom_Id(SecurityUtil.getCurrentMemberId(), roomId);
+        System.out.println("===== UserRoom 조회 완료. [1번의 쿼리 발생] =====\n");
 
+        // UserRoom이 존재하면 해당 정보 사용. 그렇지 않다면 DB에 Room 조회 쿼리 날림.
+        System.out.println("===== UserRoom.getRoom() 실행 =====");
+        Room room = optionalUserRoom
+                .map(UserRoom::getRoom)  // 이 시점에는 아직 @EntityGraph의 영향을 받지않아, 아직 조회 쿼리가 1번으로 유지됨.
+                .orElseGet(() -> roomService.findRoom(roomId));
+        System.out.println("===== UserRoom의 Room을 가져오지만 Room 내부의 변수는 사용하지않음. [추가쿼리 발생 X] =====\n");
+
+        Boolean isExistUserRoom = optionalUserRoom.isPresent();
+        System.out.println("===== UserRoom.getIsLeave() 실행 =====");
+        Integer isLeave = optionalUserRoom.map(UserRoom::getIsLeave).orElse(null);  // UserRoom이 없다면 isLeave는 null
+        System.out.println("===== UserRoom의 Room 외의 타변수를 사용. [추가쿼리 발생 X] =====\n");
+
+        System.out.println("===== UserRoom.getRoom().getRoomState() 실행 =====");
         RoomCheckAccessResponseDto roomCheckAccessResponseDto = RoomCheckAccessResponseDto.builder()
                 .isExistUserRoom(isExistUserRoom)
-                .roomState(room.getRoomState())
+                .roomState(room.getRoomState())  // @EntityGraph로 UserRoom 내부의 Room은 Eager 로딩 처리되어, N+1 문제가 발생하지 않음.
                 .isLeave(isLeave)
                 .build();
+        System.out.println("===== UserRoom의 Room 내부의 변수를 사용. [@EntityGraph 미처리시 추가쿼리 발생 O] =====\n");
+
+        System.out.println("========== !!! 메소드 종료 !!! ==========");
 
         return roomCheckAccessResponseDto;
     }
@@ -161,9 +174,8 @@ public class UserRoomServiceImpl implements UserRoomService {
     @Transactional
     @Override
     public void passSolvingProblem(Long roomId, UserPassRequestDto userPassRequestDto) {
-        User user = userService.findLoginUser();
-        Room room = roomService.findRoom(roomId);
-        UserRoom userRoom = findUserRoom(user, room);
+        UserRoom userRoom = findUserRoom(SecurityUtil.getCurrentMemberId(), roomId);  // 어차피 문제풀이 페이지는 입장 이후이기에, 부모 Room을 갖고있는 자식 UserRoom은 반드시 존재함.
+        Room room = userRoom.getRoom();  // 이 시점에는 아직 @EntityGraph의 영향을 받지않아, 아직 조회 쿼리가 1번으로 유지됨.
 
         userRoom.updateCode(userPassRequestDto.getCode());
         userRoom.updateIsLeave(1);
@@ -174,7 +186,7 @@ public class UserRoomServiceImpl implements UserRoomService {
             userRoom.updateIsPass(userPassRequestDto.getIsPass());
         }
 
-        List<UserRoom> userRoomList = room.getUserRoomList();
+        List<UserRoom> userRoomList = room.getUserRoomList();  // @EntityGraph로 UserRoom 내부의 Room은 Eager 로딩 처리되어, N+1 문제가 발생하지 않음.
         Boolean isLeaveAllUsers = userRoomList.stream()
                 .allMatch(enterUserRoom -> enterUserRoom.getIsLeave() == 1);  // 입장했던 모든 유저의 isLeave 값이 1인지 확인
         if(isLeaveAllUsers == true) room.updateRoomState(RoomState.FINISH);
@@ -183,11 +195,10 @@ public class UserRoomServiceImpl implements UserRoomService {
     @Transactional(readOnly = true)
     @Override
     public Page<CodeRoomResponseDto> findCodeRoom(Integer isPass, Integer number, String link, Pageable pageable) {
-        User loginUser = userService.findLoginUser();
         Page<UserRoom> userRoomPage;
 
         if(isPass == null && number == null && link == null) {  // 전체 정렬 조회의 경우
-            userRoomPage = userRoomRepository.findAllByIsLeaveAndUser(1, loginUser, pageable);
+            userRoomPage = userRoomRepository.findAllByIsLeaveAndUser_Id(1, SecurityUtil.getCurrentMemberId(), pageable);
         }
         else if(isPass != null && number == null && link == null) {  // 성공or실패 정렬 조회의 경우
             userRoomPage = userRoomRepository.findAllByIsLeaveAndIsPass(1, isPass, pageable);

--- a/src/main/java/com/sajang/devracebackend/service/impl/UserRoomServiceImpl.java
+++ b/src/main/java/com/sajang/devracebackend/service/impl/UserRoomServiceImpl.java
@@ -140,33 +140,33 @@ public class UserRoomServiceImpl implements UserRoomService {
     @Transactional(readOnly = true)
     @Override
     public RoomCheckAccessResponseDto checkAccess(Long roomId) {
-        System.out.println("========== !!! 메소드 시작 !!! ==========\n");
+//        System.out.println("========== !!! 메소드 시작 !!! ==========\n");
 
-        System.out.println("===== UserRoom 조회 =====");
+//        System.out.println("===== UserRoom 조회 =====");
         Optional<UserRoom> optionalUserRoom = userRoomRepository.findByUser_IdAndRoom_Id(SecurityUtil.getCurrentMemberId(), roomId);
-        System.out.println("===== UserRoom 조회 완료. [1번의 쿼리 발생] =====\n");
+//        System.out.println("===== UserRoom 조회 완료. [1번의 쿼리 발생] =====\n");
 
         // UserRoom이 존재하면 해당 정보 사용. 그렇지 않다면 DB에 Room 조회 쿼리 날림.
-        System.out.println("===== UserRoom.getRoom() 실행 =====");
+//        System.out.println("===== UserRoom.getRoom() 실행 =====");
         Room room = optionalUserRoom
                 .map(UserRoom::getRoom)  // 이 시점에는 아직 @EntityGraph의 영향을 받지않아, 아직 조회 쿼리가 1번으로 유지됨.
                 .orElseGet(() -> roomService.findRoom(roomId));
-        System.out.println("===== UserRoom의 Room을 가져오지만 Room 내부의 변수는 사용하지않음. [추가쿼리 발생 X] =====\n");
+//        System.out.println("===== UserRoom의 Room을 가져오지만 Room 내부의 변수는 사용하지않음. [추가쿼리 발생 X] =====\n");
 
         Boolean isExistUserRoom = optionalUserRoom.isPresent();
-        System.out.println("===== UserRoom.getIsLeave() 실행 =====");
+//        System.out.println("===== UserRoom.getIsLeave() 실행 =====");
         Integer isLeave = optionalUserRoom.map(UserRoom::getIsLeave).orElse(null);  // UserRoom이 없다면 isLeave는 null
-        System.out.println("===== UserRoom의 Room 외의 타변수를 사용. [추가쿼리 발생 X] =====\n");
+//        System.out.println("===== UserRoom의 Room 외의 타변수를 사용. [추가쿼리 발생 X] =====\n");
 
-        System.out.println("===== UserRoom.getRoom().getRoomState() 실행 =====");
+//        System.out.println("===== UserRoom.getRoom().getRoomState() 실행 =====");
         RoomCheckAccessResponseDto roomCheckAccessResponseDto = RoomCheckAccessResponseDto.builder()
                 .isExistUserRoom(isExistUserRoom)
                 .roomState(room.getRoomState())  // @EntityGraph로 UserRoom 내부의 Room은 Eager 로딩 처리되어, N+1 문제가 발생하지 않음.
                 .isLeave(isLeave)
                 .build();
-        System.out.println("===== UserRoom의 Room 내부의 변수를 사용. [@EntityGraph 미처리시 추가쿼리 발생 O] =====\n");
+//        System.out.println("===== UserRoom의 Room 내부의 변수를 사용. [@EntityGraph 미처리시 추가쿼리 발생 O] =====\n");
 
-        System.out.println("========== !!! 메소드 종료 !!! ==========");
+//        System.out.println("========== !!! 메소드 종료 !!! ==========");
 
         return roomCheckAccessResponseDto;
     }


### PR DESCRIPTION
# <i>PULL REQUEST</i>

## 🎋 Branch Name
refactor/#115
<!-- 윗부분 / 작업중인 브랜치 이름 기재 -->

## 🔑 Main Contents
- 'findByUserAndRoom(User user, Room room) -> findByUser_IdAndRoom_Id(Long userId, Long roomId)'로 수정.
이를 통해 추가적인 DB 접근 조회를 최소화하며 보다 직관적인 코드로 작성 가능해짐.
- EntityGraph 어노테이션을 활용한 N+1 문제 해결

==> 이러한 두가지 리팩토링을 통하여, DB 접근 성능을 보다 개선함.
<!-- 윗부분 / 주요 작업내용을 설명해주세요. -->

## 🏞 Screenshots (Optional)
![EntityGraph처리전후_SQL쿼리발생](https://github.com/Dev-Race/DevRace-backend/assets/56509933/1d74fbc1-fa13-40fa-b640-61c0a467f84b)
기존 SQL 쿼리문 (쿼리 2번 발생) / N+1 해결후 SQL 쿼리문 (쿼리 1번 발생)
<!-- 윗부분 / 스크린샷 첨부 (선택) -->

## 📋 Checks for reviewers (Optional)
```
@EntityGraph(attributePaths = {"room"})
Optional<UserRoom> findByUser_IdAndRoom_Id(Long userId, Long roomId);
```
이처럼 EntityGraph 어노테이션을 적용함으로써,
위의 스크린샷(적용전,적용후)처럼 기존에 발생하던 N+1 문제를 해결하였습니다.
<!-- 윗부분 / 리뷰어가 확인해야할 추가 체크사항을 작성하세요. (선택) -->