### PR TITLE
[#123] Refactor: 채팅방 페이징 정렬기준 및 날짜형식 리팩토링

### DIFF
--- a/src/main/java/com/sajang/devracebackend/config/RabbitConfig.java
+++ b/src/main/java/com/sajang/devracebackend/config/RabbitConfig.java
@@ -125,7 +125,7 @@ public class RabbitConfig {
     public Jackson2JsonMessageConverter jsonMessageConverter(){
         // LocalDateTime serializable을 위해
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);  // true인 경우, 실시간 통신시 LocalDateTime이 배열형식으로 컨버팅되어 프론트엔드에 전송됨.
         objectMapper.registerModule(dateTimeModule());
 
         Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);
@@ -137,7 +137,8 @@ public class RabbitConfig {
         return new JavaTimeModule();
     }
     /*
-    < LocalDateTime example / 2024-04-09T02:10:29.415171 / 2024.04.09 02H:10M:29.415171S >
+    < if 'objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);'
+    ==> LocalDateTime example / 2024-04-09T02:10:29.415171 / 2024.04.09 02H:10M:29.415171S >
     {
         "createdTime": [
             2024,

--- a/src/main/java/com/sajang/devracebackend/controller/ChatController.java
+++ b/src/main/java/com/sajang/devracebackend/controller/ChatController.java
@@ -31,10 +31,10 @@ public class ChatController {
 
 
     @GetMapping("/rooms/{roomId}/chats")
-    @Operation(summary = "채팅 내역 조회 [jwt O]", description = "- URI : /rooms/{roomId}/chats?page={페이지번호 int}  \nsize,sort 필요X (기본값 : size=10 & sort=createdTime,asc)")
+    @Operation(summary = "채팅 내역 조회 [jwt O]", description = "- URI : /rooms/{roomId}/chats?page={페이지번호 int}  \nsize,sort 필요X (기본값 : size=10 & sort=createdTime,desc)")
     public ResponseEntity<ResponseData<Slice<ChatResponseDto>>> findChatsByRoom(
             @PathVariable(value = "roomId") Long roomId,  // value=""를 작성해주어야만, Swagger에서 api테스트할때 이름값이 뜸.
-            @PageableDefault(size=10, sort="createdTime", direction = Sort.Direction.ASC) Pageable pageable) {
+            @PageableDefault(size=10, sort="createdTime", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Slice<ChatResponseDto> chatResponseDtoSlice = chatService.findChatsByRoom(roomId, pageable);
         return ResponseData.toResponseEntity(ResponseCode.READ_CHATLIST, chatResponseDtoSlice);

--- a/src/main/java/com/sajang/devracebackend/repository/UserRoomRepository.java
+++ b/src/main/java/com/sajang/devracebackend/repository/UserRoomRepository.java
@@ -30,7 +30,7 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long> {
 
     boolean existsByUserAndRoom(User user, Room room);
 
-    // 밑의 3가지 메소드 모두, 페이징에서 OneToMany 속성을 Eager 조회시키지 않을것이기에, '중복 제거 처리' 및 '배치 사이즈 선언'을 하지 않았음.
+    // 밑의 3가지 메소드 모두, 페이징에서 OneToMany 속성은 Eager 조회시키지 않을것이기에, '중복 제거 처리' 및 '배치 사이즈 선언'을 하지 않았음.
     @EntityGraph(attributePaths = {"room", "room.problem"})
     Page<UserRoom> findAllByUser_IdAndIsLeave(Long userId, Integer isLeave, Pageable pageable);
 

--- a/src/main/java/com/sajang/devracebackend/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/sajang/devracebackend/response/GlobalExceptionHandler.java
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {  // 참고로 Filter에서 throw된 에러
             Exception404.class,
             Exception500.class
     })
-    public ResponseEntity handleCustomExceptions(CustomException ex) {
+    public ResponseEntity handleCustomException(CustomException ex) {
         return logAndResponse(ex.getErrorResponseCode(), ex.getMessage());
     }
 

--- a/src/main/java/com/sajang/devracebackend/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/sajang/devracebackend/response/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {  // 참고로 Filter에서 throw된 에러
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity handleException(Exception ex) {
-        if (ex.getMessage().equals("Security Context에 인증 정보가 없습니다.")) {
+        if (ex.getMessage() != null && ex.getMessage().equals("Security Context에 인증 정보가 없습니다.")) {
             return logAndResponse(ResponseCode.anonymousUser_ERROR, ex.getMessage());  // 시큐리티 헤더의 로그인 정보가 없을때 값을 조회하면 발생.
         }
         return logAndResponse(ResponseCode.INTERNAL_SERVER_ERROR, ex.getMessage());

--- a/src/main/java/com/sajang/devracebackend/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/sajang/devracebackend/service/impl/ChatServiceImpl.java
@@ -98,7 +98,7 @@ public class ChatServiceImpl implements ChatService {
         else chatSlice = chatRepository.findAllByRoomId(roomId, pageable);
 
         // DESC로 가져온 데이터를 다시 오름차순으로 페이지별 정렬
-        List<Chat> reversedChatList = new ArrayList<>(chatSlice.getContent());  // 새로운 리스트로 만듦으로써 불변 해제.
+        List<Chat> reversedChatList = new ArrayList<>(chatSlice.getContent());  // 새로운 리스트로 만듦으로써 불변성 해제.
         Collections.reverse(reversedChatList);
 
         // 사용자 캐싱을 위한 맵 생성 (이미 검색한것은 다시 검색하지않도록 성능 향상)

--- a/src/main/java/com/sajang/devracebackend/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/sajang/devracebackend/service/impl/ChatServiceImpl.java
@@ -18,12 +18,13 @@ import com.sajang.devracebackend.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -81,23 +82,34 @@ public class ChatServiceImpl implements ChatService {
     @Transactional(readOnly = true)
     @Override
     public Slice<ChatResponseDto> findChatsByRoom(Long roomId, Pageable pageable) {
+        // < 채팅방 페이징 정렬 기준 >
+        // - 페이징을 할 때, 최신 날짜인 마지막 페이지를 0으로 설정하여 역순으로 페이징.
+        // - 한 페이지 내의 채팅은 날짜 오름차순으로 정렬.
+        // - 만약 퇴장한 경우에는, 본인 퇴장시각 이하까지의 채팅 내역을 조회.
+        // => 알고리즘: DESC로 DB에서 페이징 조회후, 각 페이지별로 날짜 오름차순 정렬.
 
         // 'UserRoom.room' Eager 로딩 (N+1 문제 해결)
         UserRoom userRoom = userRoomService.findUserRoomWithEagerRoom(SecurityUtil.getCurrentMemberId(), roomId, false, false);
         LocalDateTime leaveTime = userRoom.getLeaveTime();
 
-        // 퇴장한 경우, 본인 퇴장시각 이하까지의 채팅 내역 조회
+        // 퇴장한 경우, 본인 퇴장시각 이하까지의 채팅내역 페이징 조회
         Slice<Chat> chatSlice;
         if(userRoom.getIsLeave() == 1) chatSlice = chatRepository.findAllByRoomIdAndCreatedTimeLessThanEqual(roomId, leaveTime, pageable);
         else chatSlice = chatRepository.findAllByRoomId(roomId, pageable);
 
+        // DESC로 가져온 데이터를 다시 오름차순으로 페이지별 정렬
+        List<Chat> reversedChatList = new ArrayList<>(chatSlice.getContent());  // 새로운 리스트로 만듦으로써 불변 해제.
+        Collections.reverse(reversedChatList);
+
         // 사용자 캐싱을 위한 맵 생성 (이미 검색한것은 다시 검색하지않도록 성능 향상)
         Map<Long, User> cacheUserMap = new HashMap<>();
 
-        return chatSlice.map(chat -> {
-            Long senderId = chat.getSenderId();
-            User senderUser = cacheUserMap.computeIfAbsent(senderId, id -> userService.findUser(id));  //  만약 캐시에 senderId키의 데이터가 없다면, DB조회하고 캐시에 추가.
-            return new ChatResponseDto(chat, senderUser.getNickname(), senderUser.getImageUrl());
-        });
+        return new SliceImpl<>(reversedChatList.stream()
+                .map(chat -> {
+                    Long senderId = chat.getSenderId();
+                    User senderUser = cacheUserMap.computeIfAbsent(senderId, id -> userService.findUser(id));  // 만약 캐시에 senderId키의 데이터가 없다면, DB조회하고 캐시에 추가.
+                    return new ChatResponseDto(chat, senderUser.getNickname(), senderUser.getImageUrl());
+                })
+                .collect(Collectors.toList()), pageable, chatSlice.hasNext());
     }
 }


### PR DESCRIPTION
# <i>PULL REQUEST</i>

## 🎋 Branch Name
refactor/#123
<!-- 윗부분 / 작업중인 브랜치 이름 기재 -->

## 🔑 Main Contents
- '채팅방 무한 스크롤 Slice 페이징'에 대한 정렬기준을 다음으로 설정.
  - 페이징을 할 때, 최신 날짜인 마지막 페이지를 0으로 설정하여 역순으로 페이징.
  - 한 페이지 내의 채팅은 날짜 오름차순으로 정렬.
  - 만약 퇴장한 경우에는, 본인 퇴장시각 이하까지의 채팅 내역을 조회.
  - => 알고리즘 : DESC로 DB에서 페이징 조회후, 각 페이지별로 날짜 오름차순 정렬.
- 실시간 STOMP 통신 날짜형식 리팩토링
  - LocalDateTime을 쪼개어 배열로 보내던 방식을 기존 자료형 그대로 보내는것으로 수정.
  - => RabbitConfig의 날짜 컨버팅 설정을 true에서 false로 전환하여 해결.
<!-- 윗부분 / 주요 작업내용을 설명해주세요. -->

## 🏞 Screenshots (Optional)
<img width="718" alt="image" src="https://github.com/Dev-Race/DevRace-backend/assets/56509933/7960f6c8-0d62-417f-8571-81a8a8e423a4">
<!-- 윗부분 / 스크린샷 첨부 (선택) -->

## 📋 Checks for reviewers (Optional)
위의 스크린샷에서 보시다시피, 채팅방 페이징 정렬기준에 대한 수정 리팩토링이 성공적으로 이루어졌습니다.
<!-- 윗부분 / 리뷰어가 확인해야할 추가 체크사항을 작성하세요. (선택) -->