### PR TITLE
[#166] Fix: AWS S3 null 이미지 삭제 방지

### DIFF
--- a/src/main/java/com/sajang/devracebackend/config/SecurityConfig.java
+++ b/src/main/java/com/sajang/devracebackend/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.GET, "/users").hasAnyAuthority("ROLE_GUEST", "ROLE_USER", "ROLE_ADMIN")  // 사용자 프로필 조회 api는 ROLE_GUEST 권한 로그인 사용자도 사용 가능. 이는 회원가입시, 변경전 기존 OAuth2 소셜 사용자 정보를 조회해야하기 때문임.
 
                             // .requestMatchers("/**").permitAll()  // Test 용도
-                            .requestMatchers("/", "/error", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**", "/swagger/**", "/health").permitAll()
+                            .requestMatchers("/", "/error", "/favicon.ico", "/v3/api-docs/**", "/swagger-ui/**", "/swagger/**", "/health").permitAll()
                             .requestMatchers("/ws/**", "/oauth2/**", "/reissue").permitAll()
 
                             .anyRequest().hasAnyAuthority("ROLE_USER", "ROLE_ADMIN");  // permit 지정한 경로들 외에는 전부 USER나 ADMIN 권한이 있어야지 url을 이용 가능하다. (GUEST 불가능)

--- a/src/main/java/com/sajang/devracebackend/service/impl/AwsS3ServiceImpl.java
+++ b/src/main/java/com/sajang/devracebackend/service/impl/AwsS3ServiceImpl.java
@@ -28,9 +28,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
     @Transactional
     @Override
     public String uploadImage(MultipartFile file) throws IOException {
-        if(file == null) {
-            return null;
-        }
+        if(file == null) return null;
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(file.getContentType());
@@ -47,6 +45,7 @@ public class AwsS3ServiceImpl implements AwsS3Service {
     @Transactional
     @Override
     public void deleteImage(String fileUrl) {  // 사진 업로드를 위해 이전 사진을 제거하는 용도 및 차후 기본이미지로 변경시 사용 예정 메소드
+        if(fileUrl == null) return;  // 기본 이미지로 설정되어있는 경우, 이미지 삭제처리 X.
         String fileName = fileUrl.split(".com/")[1];
 
         try {


### PR DESCRIPTION
# <i>PULL REQUEST</i>

## 🎋 Branch Name
fix/#166
<!-- 윗부분 / 작업중인 브랜치 이름 기재 -->

## 🔑 Main Contents
AWS S3 deleteImage() 메소드의 파라미터값이 null일 경우, 메소드를 정상 종료하도록 기본 이미지 삭제 처리를 방지함.
<!-- 윗부분 / 주요 작업내용을 설명해주세요. -->

## 📋 Checks for reviewers (Optional)
이는 수정 사항에 대한 추가 설명입니다.
```
if(fileUrl == null) return;  // 기본 이미지로 설정되어있는 경우, 이미지 삭제처리 X. (밑의 에러 발생 방지)
String fileName = fileUrl.split(".com/")[1];  // fileUrl==null 경우, 여기서 500 에러 발생.
```
<!-- 윗부분 / 리뷰어가 확인해야할 추가 체크사항을 작성하세요. (선택) -->